### PR TITLE
Added key_options option

### DIFF
--- a/Form/Type/KeyValueRowType.php
+++ b/Form/Type/KeyValueRowType.php
@@ -13,11 +13,12 @@ class KeyValueRowType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         if (null === $options['allowed_keys']) {
-            $builder->add('key', 'text', array(
-            ));
+            $builder->add('key', 'text', $options['key_options']
+            );
         } else {
-            $builder->add('key', 'choice', array(
+            $builder->add('key', 'choice', array_merge(array(
                 'choice_list' => new SimpleChoiceList($options['allowed_keys'])
+            ), $options['key_options']
             ));
         }
 
@@ -32,6 +33,7 @@ class KeyValueRowType extends AbstractType
     public function setDefaultOptions(OptionsResolverInterface $resolver)
     {
         $resolver->setDefaults(array(
+            'key_options' => array(),
             'value_options' => array(),
             'allowed_keys' => null
         ));
@@ -39,6 +41,4 @@ class KeyValueRowType extends AbstractType
         $resolver->setRequired(array('value_type'));
         $resolver->setAllowedTypes(array('allowed_keys' => array('null', 'array')));
     }
-
-
-} 
+}

--- a/Form/Type/KeyValueType.php
+++ b/Form/Type/KeyValueType.php
@@ -42,12 +42,14 @@ class KeyValueType extends AbstractType
             'type' => 'burgov_key_value_row',
             'allow_add' => true,
             'allow_delete' => true,
+            'key_options' => array(),
             'value_options' => array(),
             'allowed_keys' => null,
             'use_container_object' => false,
             'options' => function(Options $options) {
                 return array(
                     'value_type' => $options['value_type'],
+                    'key_options' => $options['key_options'],
                     'value_options' => $options['value_options'],
                     'allowed_keys' => $options['allowed_keys']
                 );

--- a/Tests/Form/Type/KeyValueTypeTest.php
+++ b/Tests/Form/Type/KeyValueTypeTest.php
@@ -43,16 +43,21 @@ class KeyValueTypeTest extends TypeTestCase
             'key3' => '1',
         );
 
-        $builder = $this->factory->createBuilder('burgov_key_value', $originalData, array('value_type' => 'text'));
+        $builder = $this->factory->createBuilder('burgov_key_value', $originalData, array(
+            'value_type' => 'text',
+            'key_options' => array('label' => 'label_key'),
+            'value_options' => array('label' => 'label_value')));
 
         $form = $builder->getForm();
 
         $this->assertFormTypes(array('text', 'text'), $form);
+        $this->assertFormOptions(array(array('label' => 'label_key'), array('label' => 'label_value')), $form);
 
         $form->submit($submitData);
         $this->assertTrue($form->isValid(), $form->getErrorsAsString());
 
         $this->assertFormTypes(array('text', 'text', 'text'), $form);
+        $this->assertFormOptions(array(array('label' => 'label_key'), array('label' => 'label_value')), $form);
 
         $this->assertSame($expectedData, $form->getData());
     }
@@ -67,13 +72,18 @@ class KeyValueTypeTest extends TypeTestCase
         $obj2->id = 2;
         $obj2->name = 'choice2';
 
-        $builder = $this->factory->createBuilder('burgov_key_value', null, array('value_type' => 'choice', 'value_options' => array(
-            'choice_list' => new ObjectChoiceList(array($obj1, $obj2), 'name', array(), null, 'id')
-        )));
+        $builder = $this->factory->createBuilder('burgov_key_value', null, array(
+            'value_type' => 'choice',
+            'key_options' => array('label' => 'label_key'),
+            'value_options' => array(
+                'choice_list' => new ObjectChoiceList(array($obj1, $obj2), 'name', array(), null, 'id'),
+                'label' => 'label_value'
+            )));
 
         $form = $builder->getForm();
 
         $this->assertFormTypes(array(), $form);
+        $this->assertFormOptions(array(array('label' => 'label_key'), array('label' => 'label_value')), $form);
 
         $form->submit(array(
             array(
@@ -87,6 +97,7 @@ class KeyValueTypeTest extends TypeTestCase
         ));
 
         $this->assertFormTypes(array('choice', 'choice'), $form);
+        $this->assertFormOptions(array(array('label' => 'label_key'), array('label' => 'label_value')), $form);
 
         $this->assertTrue($form->isValid());
 
@@ -98,6 +109,18 @@ class KeyValueTypeTest extends TypeTestCase
         $this->assertCount(count($types), $form);
         foreach ($types as $key => $type) {
             $this->assertEquals($type, $form->get($key)->get('value')->getConfig()->getType()->getInnerType()->getName());
+        }
+    }
+
+    private function assertFormOptions(array $options, $form)
+    {
+        for ($i = 0; $i < count($form); $i++) {
+            foreach ($options[0] as $option => $optionValue) {
+                $this->assertEquals($optionValue, $form->get($i)->get('key')->getConfig()->getOption($option));
+            }
+            foreach ($options[1] as $option => $optionValue) {
+                $this->assertEquals($optionValue, $form->get($i)->get('value')->getConfig()->getOption($option));
+            }
         }
     }
 }


### PR DESCRIPTION
This can be useful to change the labels, such as:
```php
            ->add('details', 'burgov_key_value', array(
                'label' => $this->trans('user.form.details', array(), 'user'),
                'value_type' => 'text',
                'key_options' => array('label' => $this->trans('user.form.details.key', array(), 'user')),
                'value_options' => array('label' => $this->trans('user.form.details.value', array(), 'user')),
                'use_container_object' => true))
```