### PR TITLE
Remove useless IF

### DIFF
--- a/Form/Type/KeyValueType.php
+++ b/Form/Type/KeyValueType.php
@@ -68,14 +68,7 @@ class KeyValueType extends AbstractType
         ));
 
         $resolver->setRequired(array('value_type'));
-
-        if (method_exists($resolver, 'setDefined')) {
-            // Symfony 2.6+ API
-            $resolver->setAllowedTypes(array('allowed_keys' => array('null', 'array')));
-        } else {
-            // Symfony <2.6 API
-            $resolver->setAllowedTypes(array('allowed_keys' => array('null', 'array')));
-        }
+        $resolver->setAllowedTypes(array('allowed_keys' => array('null', 'array')));
     }
 
     public function getParent()


### PR DESCRIPTION
This `if` seems dubious since both its branches are the exact same code.

It was introduced by @WouterJ while introducing support for Symfony 3.0, maybe I missed something and it IS useful...