### PR TITLE
Make it impossible to install the bundle with symfony 2.8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,9 @@
         "php": ">=5.3.3",
         "symfony/form": "~2.3|3.*"
     },
+    "conflict": {
+        "symfony/form": "2.8.1"
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "1.1-dev"


### PR DESCRIPTION
In 2.8.1, there is a regression in the collection type (fixed by https://github.com/symfony/symfony/pull/17162 in master). This makes this bundle useless (as options are not chained to the entry type correctly, you always get an exception about missing required option 'value_type' when using `burgov_key_value`).