### PR TITLE
use FQCN form types instead of names

### DIFF
--- a/Form/Type/KeyValueType.php
+++ b/Form/Type/KeyValueType.php
@@ -4,6 +4,7 @@ namespace Burgov\Bundle\KeyValueFormBundle\Form\Type;
 
 use Burgov\Bundle\KeyValueFormBundle\Form\DataTransformer\HashToKeyValueArrayTransformer;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
@@ -48,10 +49,10 @@ class KeyValueType extends AbstractType
         $isSf28 = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix');
 
         $resolver->setDefaults(array(
-            $isSf28 ? 'entry_type' : 'type' => 'burgov_key_value_row',
+            $isSf28 ? 'entry_type' : 'type' => $isSf28 ? KeyValueRowType::class : 'burgov_key_value_row',
             'allow_add' => true,
             'allow_delete' => true,
-            'key_type' => 'text',
+            'key_type' => $isSf28 ? TextType::class : 'text',
             'key_options' => array(),
             'value_options' => array(),
             'allowed_keys' => null,

--- a/README.md
+++ b/README.md
@@ -29,14 +29,17 @@ public function registerBundles()
 Usage
 -----
 
-To add to your form, use the alias `burgov_key_value`:
+To add to your form, use the `KeyValueType` type:
 
 ```php
-$builder->add('parameters', 'burgov_key_value', array('value_type' => 'text'));
+use Burgov\Bundle\KeyValueFormBundle\Form\Type\KeyValueType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+
+$builder->add('parameters', KeyValueType::class, array('value_type' => TextType::class));
 
 // or
 
-$formFactory->create('burgov_key_value', $data, array('value_type' => 'text'));
+$formFactory->create(KeyValueType::class, $data, array('value_type' => TextType::class));
 ```
 
 The type extends the collection type, so for rendering it in the browser, the same logic is used. See the
@@ -53,7 +56,7 @@ The type adds four options to the collection type options, of which one is requi
   * `use_container_object` see explanation below at 'The KeyValueCollection'
 
 Besides that, this type overrides some defaults of the collection type and it's recommended you don't change them:
-`type` is set to `burgov_key_value_row` and `allow_add` and `allow_delete` are always `true`.
+`type` is set to `BurgovKeyValueRow::class` and `allow_add` and `allow_delete` are always `true`.
 
 Working with SonataAdminBundle
 ------------------------------
@@ -93,7 +96,7 @@ it, you need to set the `use_container_object` option on the form type to
 /** @var $builder Symfony\Component\Form\FormBuilderInterface */
 $builder->add('options', 'burgov_key_value', array(
     'required' => false,
-    'value_type' => 'text',
+    'value_type' => TextType::class,
     'use_container_object' => true,
 ));
 ```


### PR DESCRIPTION
follow 2.8+ [recommendations](https://github.com/symfony/symfony/blob/2.8/UPGRADE-2.8.md#form)
 > Type names were deprecated and will be removed in Symfony 3.0. Instead of referencing types by name, you should reference them by their fully-qualified class name (FQCN) instead.

also makes it easier to use without having to register the type beforehand (if used outside of the Symfony Framework).