### PR TITLE
Use FQCN instead of form name in Symfony 2.8+

### DIFF
--- a/Form/Type/KeyValueRowType.php
+++ b/Form/Type/KeyValueRowType.php
@@ -41,8 +41,11 @@ class KeyValueRowType extends AbstractType
 
     public function configureOptions(OptionsResolver $resolver)
     {
+        // check if Form component version 2.8+ is used
+        $isSf28 = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix');
+
         $resolver->setDefaults(array(
-            'key_type' => 'text',
+            'key_type' => $isSf28 ? 'Symfony\Component\Form\Extension\Core\Type\TextType' : 'text',
             'key_options' => array(),
             'value_options' => array(),
             'allowed_keys' => null

--- a/Form/Type/KeyValueType.php
+++ b/Form/Type/KeyValueType.php
@@ -48,10 +48,10 @@ class KeyValueType extends AbstractType
         $isSf28 = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix');
 
         $resolver->setDefaults(array(
-            $isSf28 ? 'entry_type' : 'type' => 'burgov_key_value_row',
+            $isSf28 ? 'entry_type' : 'type' => $isSf28 ? __NAMESPACE__.'\KeyValueRowType' : 'burgov_key_value_row',
             'allow_add' => true,
             'allow_delete' => true,
-            'key_type' => 'text',
+            'key_type' => $isSf28 ? 'Symfony\Component\Form\Extension\Core\Type\TextType' : 'text',
             'key_options' => array(),
             'value_options' => array(),
             'allowed_keys' => null,


### PR DESCRIPTION
While testing with the Symfony CMF on Symfony 3, I found that this bundle has some issues with Symfony 3 support. I hope this PR has fixed them all.

@Burgov I cannot make much sense of the tests and have a real hard time getting them pass on Symfony 3. Can you please fix these tests? (dropping Symfony 2.3 support would help quite a lot and please note that it'll reach end of maintaince this month)