### PR TITLE
Fix Symfony 4.2 deprecations for TreeBuilder

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -17,8 +17,14 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('burgov_key_value_form');
+        $treeBuilder = new TreeBuilder('burgov_key_value_form');
+
+        if (method_exists($treeBuilder, 'getRootNode')) {
+            $rootNode = $treeBuilder->getRootNode();
+        } else {
+            // BC layer for symfony/config 4.1 and older
+            $rootNode = $treeBuilder->root('burgov_key_value_form');
+        }
 
         // Here you should define the parameters that are allowed to
         // configure your bundle. See the documentation linked above for


### PR DESCRIPTION
Otherwise this bundle won't work with Symfony 5