### PR TITLE
Fix bad method names in README (getclass and get_type)

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ class Model
             return iterator_to_array($data);
         }
 
-        throw new InvalidArgumentException(sprintf('Expected array, Traversable or KeyValueContainer, got "%s"', is_object($data) ? get_class($data) : get_type($data)));
+        throw new InvalidArgumentException(sprintf('Expected array, Traversable or KeyValueContainer, got "%s"', is_object($data) ? get_class($data) : gettype($data)));
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ class Model
             return iterator_to_array($data);
         }
 
-        throw new InvalidArgumentException(sprintf('Expected array, Traversable or KeyValueContainer, got "%s"', is_object($data) ? getclass($data) : get_type($data)));
+        throw new InvalidArgumentException(sprintf('Expected array, Traversable or KeyValueContainer, got "%s"', is_object($data) ? get_class($data) : get_type($data)));
     }
 }
 ```


### PR DESCRIPTION
The `getclass($data)` call should be rewritten to `get_class($data)`
(cf. https://www.php.net/get-class).
The `get_type($data)` call should be rewritten to `gettype($data)`
(cf. https://www.php.net/gettype)

Otherwise, it would result in the following Fatal Error (for getclass)
`PHP Fatal error:  Uncaught Error: Call to undefined function getclass()` 