### PR TITLE
Add PHP platform for 7.4 in composer.json and switch away from array_…

### DIFF
--- a/Form/DataTransformer/HashToKeyValueArrayTransformer.php
+++ b/Form/DataTransformer/HashToKeyValueArrayTransformer.php
@@ -41,7 +41,7 @@ class HashToKeyValueArrayTransformer implements DataTransformerInterface
                 throw new TransformationFailedException;
             }
 
-            if (array_key_exists($data['key'], $return)) {
+            if (isset($data['key'], $return)) {
                 throw new TransformationFailedException('Duplicate key detected');
             }
 

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "psr-4": { "Burgov\\Bundle\\KeyValueFormBundle\\": "" }
     },
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.3.3|^7.4",
         "symfony/form": "^2.3|^3.0|^4.0|^5.0"
     },
     "conflict": {


### PR DESCRIPTION
…key_exists inside of HashToKeyValueArrayTransformer.php

array_key_exists is deprecated for use on objects in php 7.4 (preparing for PHP 8). 