### PR TITLE
7.4 deprecation removal on array_key_exists

### DIFF
--- a/Form/DataTransformer/HashToKeyValueArrayTransformer.php
+++ b/Form/DataTransformer/HashToKeyValueArrayTransformer.php
@@ -41,7 +41,7 @@ class HashToKeyValueArrayTransformer implements DataTransformerInterface
                 throw new TransformationFailedException;
             }
 
-            if (isset($data['key'], $return)) {
+            if (isset($data['key'], $return[$data['key']])) {
                 throw new TransformationFailedException('Duplicate key detected');
             }
 

--- a/Form/DataTransformer/HashToKeyValueArrayTransformer.php
+++ b/Form/DataTransformer/HashToKeyValueArrayTransformer.php
@@ -41,7 +41,7 @@ class HashToKeyValueArrayTransformer implements DataTransformerInterface
                 throw new TransformationFailedException;
             }
 
-            if (array_key_exists($data['key'], $return)) {
+            if (isset($data['key'], $return)) {
                 throw new TransformationFailedException('Duplicate key detected');
             }
 

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "psr-4": { "Burgov\\Bundle\\KeyValueFormBundle\\": "" }
     },
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.3.3|^7.4",
         "symfony/form": "^2.3|^3.0|^4.0|^5.0"
     },
     "conflict": {


### PR DESCRIPTION
(Second attempt, reliased I didn't even look at last PR) 

Anyway, quite straightforward, 

Currently the $return is set based on 

> $return = $this->useContainerObject ? new KeyValueContainer() : array();

This is being changed to use isset due to php 7.4 deprecation on objects when using array_key_exists

